### PR TITLE
Add Nextcloud 33 and 34 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to the SURF Trashbin app are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+- Support for Nextcloud 33 and 34 (`max-version` raised from 32 to 34).
+- Explicit `<php min-version="8.2" max-version="8.5"/>` dependency in `info.xml`,
+  matching the PHP floor that Nextcloud 33/34 require.
+- `<types><filesystem/></types>` declaration in `info.xml`. **This is a
+  functional fix, not just metadata.** The Nextcloud WebDAV/Sabre entry point
+  (`remote.php`), which the Files trashbin UI uses for delete / restore /
+  permanent-delete, only loads apps of type `filesystem` (and
+  `logging` / `authentication`). Without this type the app's bootstrap never ran
+  on that request path, so the `\OCP\Trashbin`/`delete` hook slot was never
+  registered and **permanent-delete cleanup silently failed** (the functional
+  account and project-owner trashbin copies were left behind). Verified end-to-end
+  on Nextcloud 33.0.4.
+
+### Changed
+- `lib/AppInfo/Application.php` now implements `IBootstrap` more idiomatically:
+  the typed event listeners (`NodeDeletedEvent`, `NodeRestoredEvent`) are
+  registered in `register()` via `IRegistrationContext::registerEventListener()`.
+  The legacy `Util::connectHook('\OCP\Trashbin', 'delete', …)` registration is
+  **kept in the constructor on purpose** — `IBootstrap::boot()` is not invoked
+  for this app on the WebDAV request path, whereas the `App` constructor always
+  runs when the app is loaded. (See `UPGRADING.md` for the longer-term plan.)
+- `composer.json`: development baseline bumped to match supported servers —
+  `nextcloud/ocp` `dev-stable30` → `dev-stable33`, `phpunit/phpunit` `^9` → `^10`,
+  platform/`require` PHP `8.0` → `>=8.2 <=8.5`.
+
+### Notes
+- No change was required to the actual trashbin logic: every Nextcloud API the
+  app calls (the legacy `\OCP\Trashbin` hook, `\OC\Files\View`,
+  `OCA\Files_Trashbin\Events\NodeRestoredEvent`,
+  `OCP\Files\Events\Node\NodeDeletedEvent`, `Util::computerFileSize`,
+  `QBMapper`/`IDBConnection`) is still present and behaves the same on Nextcloud
+  33 and 34. The only breaking issue was the app not being loaded on the WebDAV
+  path; see **Added → `<types>`** above.
+
+## [0.0.1]
+
+### Added
+- Initial release: enables restore and permanent-delete capabilities for the
+  project owner of files/folders deleted by project users on Research Drive
+  functional accounts (`f_account -> project-owner -> project-users`).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,94 @@
+# Upgrading & future Nextcloud support
+
+This document tracks the Nextcloud APIs this app depends on that are
+**deprecated or internal**, the risk they carry for future major versions, and
+the recommended migration path. None of these are broken on Nextcloud 31–34
+(verified against the `stable33`/`stable34` server source and end-to-end on a
+live NC 33.0.4 instance), so **no action is required today** — this is a
+forward-looking checklist for whoever bumps the app to NC 35+.
+
+## How the app is loaded (important context)
+
+The app must be loaded on the **WebDAV/Sabre request path** (`remote.php`),
+because the Files trashbin UI performs delete / restore / permanent-delete
+through it. That path only loads apps declared with an app type of
+`filesystem`, `logging`, or `authentication`. This app therefore declares:
+
+```xml
+<types>
+    <filesystem/>
+</types>
+```
+
+Removing this declaration silently breaks permanent-delete cleanup (the slot for
+the `\OCP\Trashbin`/`delete` hook is never registered on the WebDAV path). Keep
+it.
+
+## Deprecated / internal API surfaces
+
+### 1. Legacy hook: `Util::connectHook('\OCP\Trashbin', 'delete', …)`
+
+- **Where:** `lib/AppInfo/Application.php` (constructor) →
+  `lib/Hooks/TrashbinHook.php::permanentDelete()`.
+- **State:** `@deprecated 21.0.0`. Still fully functional on NC 33 and 34 —
+  `apps/files_trashbin/lib/Trashbin.php` still emits
+  `\OC_Hook::emit('\OCP\Trashbin', 'delete', ['path' => …])` on permanent delete,
+  and `OC_Hook` still dispatches it.
+- **Why it is still here:** there is **no typed event** for *permanent delete*
+  in the trashbin app. `apps/files_trashbin/lib/Events/` only contains
+  `BeforeNodeRestoredEvent`, `MoveToTrashEvent`, and `NodeRestoredEvent` — none
+  for permanent deletion.
+- **Why the registration is in the constructor (not `boot()`):** `IBootstrap::boot()`
+  is not invoked for this app on the WebDAV request path; the `App` constructor
+  always runs when the app is loaded. Moving the `connectHook` call into `boot()`
+  silently breaks permanent-delete. Do not move it.
+- **Migration path (NC 35+ if the hook is ever removed):** switch to the generic
+  storage-layer event `OCP\Files\Events\Node\NodeDeletedEvent`, registered via
+  `IRegistrationContext::registerEventListener()`. Caveat: that event fires for
+  **every** node deletion, so the listener must filter on the node path being
+  under `…/files_trashbin/files/` to replicate the precisely-scoped legacy hook.
+  This is a behaviour change with added complexity — only do it when forced.
+
+### 2. Internal class: `\OC\Files\View`
+
+- **Where:** `lib/Service/TrashbinService.php` and `lib/Hooks/TrashbinHook.php`
+  (`new \OC\Files\View(…)`; `unlink`, `is_dir`, `mkdir`, `file_exists`,
+  `getDirectoryContent`, `resolvePath`, and the
+  `resolvePath() → IStorage → getUpdater()->update()` chain).
+- **State:** `@internal since 33.0.0` (note: **internal**, not `@deprecated`).
+  No runtime warning, no removal scheduled in 33/34. All methods exist with
+  backward-compatible signatures on both branches.
+- **Why it is still here:** the app does low-level trashbin file manipulation
+  (including a raw `copy()` plus a cache `update()` for the zero-quota case) that
+  has no clean equivalent in the public Node API today.
+- **Migration path (NC 35+):** move to `OCP\Files\IRootFolder` and the
+  `Folder`/`File`/`Node` API. Validate the zero-quota copy path carefully — that
+  is the part most coupled to `View` and the storage `Updater`.
+
+### 3. Direct SQL / table access
+
+- **Where:** `lib/Db/FileCacheMapper.php` (raw SQL against `oc_filecache` /
+  `oc_storages`), `lib/Db/TrashbinMapper.php`, `lib/Db/ShareMapper.php`.
+- **State:** works on 33/34. `QBMapper`, `IDBConnection::getQueryBuilder()`,
+  `executeQuery()`, `executeStatement()` are all non-deprecated. NC 34 adds a
+  soft `@note` suggesting `getTypedQueryBuilder()` but does **not** deprecate the
+  current methods.
+- **Risk:** the raw SQL hardcodes the `oc_` table prefix in places (e.g.
+  `join oc_storages`, `from oc_filecache`) instead of using `*PREFIX*`
+  consistently. This breaks on any installation with a non-default DB table
+  prefix.
+- **Migration path:** replace remaining hardcoded `oc_` prefixes with `*PREFIX*`
+  (or QueryBuilder), so the app works regardless of the configured table prefix.
+
+## Quick checklist when bumping to a new Nextcloud major
+
+1. Raise `<nextcloud max-version>` in `appinfo/info.xml`.
+2. Confirm the PHP range in `info.xml` and `composer.json` still matches the
+   server's required PHP.
+3. Bump `nextcloud/ocp` in `composer.json` to the new `dev-stableXX`.
+4. Re-run the end-to-end flow (delete → restore → permanent-delete) on a live
+   instance — unit/source checks alone do **not** catch the WebDAV-loading and
+   hook-dispatch issues that only surface at runtime.
+5. Check whether `\OCP\Trashbin`/`delete` is still emitted and whether
+   `\OC\Files\View` is still present; if either is gone, follow the migration
+   paths above.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,9 +14,22 @@
     <author mail="antoon.prins@surf.nl" >Antoon Prins</author>
     <namespace>SURFTrashbin</namespace>
     <category>integration</category>
+    <!--
+        The 'filesystem' type ensures this app is loaded on the WebDAV/Sabre
+        (remote.php) request path. That path only loads apps of type
+        filesystem/logging/authentication, and the trashbin UI performs its
+        delete/restore/permanent-delete operations through it. Without this,
+        the App constructor never runs there, the '\OCP\Trashbin'/'delete'
+        hook slot is never registered, and permanent-delete cleanup silently
+        fails.
+    -->
+    <types>
+        <filesystem/>
+    </types>
     <bugs>https://github.com/sara-nl/nc-surf_trashbin/issues</bugs>
     <dependencies>
-        <nextcloud min-version="31" max-version="32"/>
+        <php min-version="8.2" max-version="8.5"/>
+        <nextcloud min-version="31" max-version="34"/>
     </dependencies>
 
 </info>

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,15 @@
 			"name": "Antoon Prins"
 		}
 	],
+	"require": {
+		"php": ">=8.2 <=8.5"
+	},
 	"require-dev": {
-		"phpunit/phpunit": "^9",
+		"phpunit/phpunit": "^10",
 		"sabre/dav": "^4.6.0",
 		"sabre/xml": "^2.0.1",
 		"symfony/event-dispatcher": "^5.3.11",
-		"nextcloud/ocp": "dev-stable30",
+		"nextcloud/ocp": "dev-stable33",
 		"psalm/phar": "^5.17.0",
 		"nextcloud/coding-standard": "^v1.1.1",
         "squizlabs/php_codesniffer": "3.*"
@@ -33,7 +36,7 @@
 			"composer/package-versions-deprecated": true
 		},
 		"platform": {
-			"php": "8.0"
+			"php": "8.2"
 		}
 	}
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -18,7 +18,6 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\IUserSession;
 use OCP\Util;
@@ -32,27 +31,38 @@ class Application extends App implements IBootstrap
         parent::__construct(self::APP_ID);
 
         /**
-         * There are 3 events we enhance: 
-         * Node deleted event: move an item to the trashbin
-         * Node restored event: restore a node
-         * Pemanent delete event: delete a node permanently 
+         * Permanent delete event: delete a node permanently.
+         *
+         * The files_trashbin app emits the legacy '\OCP\Trashbin'/'delete' hook on
+         * permanent delete (verified against NC stable33/stable34; there is no typed
+         * event equivalent). We register the slot here in the constructor rather than in
+         * boot(), because the WebDAV/Sabre request path (used by the Files trashbin UI)
+         * does not invoke IBootstrap::boot() for every app, whereas the App constructor
+         * always runs when the app is loaded. Registering in boot() silently breaks the
+         * permanent-delete cleanup.
          */
-        $dispatcher = $this->getContainer()->get(IEventDispatcher::class);
-        // move a node to the trashbin event
-        $dispatcher->addServiceListener(NodeDeletedEvent::class, NodeDeletedEventListener::class);
-        // restore a node event
-        $dispatcher->addServiceListener(NodeRestoredEvent::class, NodeRestoredEventListener::class);
-        // permanently delete a node event
+        $container = $this->getContainer();
         $trashbinHook = new TrashbinHook(
-            $this->getContainer()->get(TrashbinService::class),
-            $this->getContainer()->get(FileCacheMapper::class),
-            $this->getContainer()->get(TrashbinMapper::class),
-            $this->getContainer()->get(IUserSession::class)
+            $container->get(TrashbinService::class),
+            $container->get(FileCacheMapper::class),
+            $container->get(TrashbinMapper::class),
+            $container->get(IUserSession::class)
         );
         Util::connectHook('\OCP\Trashbin', 'delete', $trashbinHook, 'permanentDelete');
     }
 
-    public function register(IRegistrationContext $context): void {}
+    /**
+     * There are 2 events we enhance via the typed event dispatcher:
+     * Node deleted event: move an item to the trashbin
+     * Node restored event: restore a node
+     */
+    public function register(IRegistrationContext $context): void
+    {
+        // move a node to the trashbin event
+        $context->registerEventListener(NodeDeletedEvent::class, NodeDeletedEventListener::class);
+        // restore a node event
+        $context->registerEventListener(NodeRestoredEvent::class, NodeRestoredEventListener::class);
+    }
 
     public function boot(IBootContext $context): void {}
 }


### PR DESCRIPTION
## Summary

Makes the app installable and functional on **Nextcloud 33 and 34** (range raised to 31..34) and aligns the PHP / dev baseline with what those versions require.

While validating this **end-to-end on a live NC 33.0.4 instance**, I found that permanent-delete cleanup was **silently failing** — and fixed it.

## The functional fix: `<types><filesystem/></types>`

The Files trashbin UI performs delete / restore / permanent-delete through the **WebDAV/Sabre entry point** (`remote.php`). That path only loads apps declared with an app type of `filesystem` / `logging` / `authentication`. This app declared **no `<types>`**, so its bootstrap never ran on that path → the `\OCP\Trashbin`/`delete` hook slot was never registered → on permanent delete, the **functional-account and project-owner trashbin copies were left behind** (no error, just silent data residue).

Declaring `<types><filesystem/></types>` fixes it. This was almost certainly a latent issue before 33/34 as well; it only surfaced because this round was validated against real trashbin operations rather than source inspection alone.

## Changes

- **`appinfo/info.xml`**
  - `nextcloud` `max-version` 32 → **34**
  - add `<php min-version="8.2" max-version="8.5"/>` (NC 33/34 PHP floor)
  - add `<types><filesystem/></types>` *(functional fix, see above)*
- **`lib/AppInfo/Application.php`**
  - register the typed event listeners (`NodeDeletedEvent`, `NodeRestoredEvent`) via `IRegistrationContext::registerEventListener()` in `register()`
  - **keep** the legacy `Util::connectHook('\OCP\Trashbin', 'delete', …)` registration in the constructor on purpose — `IBootstrap::boot()` is not invoked for this app on the WebDAV path, so moving it there breaks permanent-delete
- **`composer.json`**
  - `nextcloud/ocp` `dev-stable30` → `dev-stable33`
  - `phpunit/phpunit` `^9` → `^10`
  - PHP platform/`require` `8.0` → `>=8.2 <=8.5`
- **`CHANGELOG.md`** (new) and **`UPGRADING.md`** (new) — the latter documents the deprecated/internal API surfaces (`connectHook`, `\OC\Files\View`, hardcoded `oc_` SQL prefix) and their future migration paths for NC 35+.

## API compatibility note

No change was needed to the trashbin logic itself: the legacy `\OCP\Trashbin` hook, `\OC\Files\View`, `OCA\Files_Trashbin\Events\NodeRestoredEvent`, `OCP\Files\Events\Node\NodeDeletedEvent`, `Util::computerFileSize`, and the `QBMapper`/`IDBConnection` calls are all present and unchanged on NC 33 and 34.

## Testing

Verified **end-to-end on NC 33.0.4** with a real `f_account → project-owner → project-user` share chain:

| Scenario | Result |
|---|---|
| Project user deletes a file | ✅ Copy appears in the trashbin of the user, the project owner **and** the functional account (rows + physical files; owner copy has correct content) |
| Project owner restores | ✅ All accounts' trashbins (DB + disk) cleaned; file restored to the source folder |
| Permanent delete (the `connectHook` path) | ✅ Hook fires; all trashbins **and** the functional-account filecache fully cleaned |

No app errors during the full flow. NC 34 was verified against the `stable34` server source (not yet runtime-tested — no NC 34 instance available).